### PR TITLE
Fix incorrect docs about `special` default.

### DIFF
--- a/website/docs/r/string.html.md
+++ b/website/docs/r/string.html.md
@@ -44,7 +44,7 @@ The following arguments are supported:
 * `number` - (Optional) (default true) Include numeric characters in random
   string.
 
-* `special` - (Optional) (default false) Include special characters in random
+* `special` - (Optional) (default true) Include special characters in random
   string. These are '!@#$%&*()-_=+[]{}<>:?'
 
 * `override_special` - (Optional) Supply your own list of special characters to


### PR DESCRIPTION
`special` actually defaults to true...

https://github.com/terraform-providers/terraform-provider-random/blob/4fa426a0abefc452001cc3c55026b7e89b447bce/random/resource_string.go#L27-L34