### PR TITLE
db passwords have limited special characters

### DIFF
--- a/website/docs/r/string.html.md
+++ b/website/docs/r/string.html.md
@@ -20,6 +20,7 @@ ie. if length = 4 and special = true, output could be 'Aa0#' or '1111'
 resource "random_string" "password" {
   length = 16
   special = true
+  override_special = "/@\" "
 }
 
 resource "aws_db_instance" "example" {


### PR DESCRIPTION
`Error creating DB Instance: InvalidParameterValue: The parameter MasterUserPassword is not a valid password. Only printable ASCII characters besides '/', '@', '"', ' ' may be used.`