### PR TITLE
Add whitespace so syntax highlighting works in random_integer example

### DIFF
--- a/website/docs/r/integer.html.md
+++ b/website/docs/r/integer.html.md
@@ -19,6 +19,7 @@ exist concurrently.
 
 The following example shows how to generate a random priority between 1 and 99999 for
 a `aws_alb_listener_rule` resource:
+
 ```hcl
 resource "random_integer" "priority" {
   min     = 1


### PR DESCRIPTION
The current example on https://www.terraform.io/docs/providers/random/r/integer.html isn't rendering correctly:

![screen shot 2017-12-07 at 11 39 03](https://user-images.githubusercontent.com/301220/33713485-441154a8-db43-11e7-82e4-9ef0e1993952.png)
