### PR TITLE
Scrub ID for random_string resource

### DIFF
--- a/random/resource_string.go
+++ b/random/resource_string.go
@@ -162,7 +162,7 @@ func CreateString(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	d.Set("result", string(result))
-	d.SetId(string(result))
+	d.SetId("none")
 	return nil
 }
 


### PR DESCRIPTION
Fixes #17

Sets the ID for `random_string` resources to `"none"`.

```
$ terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Note: You didn't specify an "-out" parameter to save this plan, so when
"apply" is called, Terraform can't guarantee this is what will execute.

  + random_string.password
      length:  "16"
      lower:   "true"
      number:  "true"
      result:  "<computed>"
      special: "true"
      upper:   "true"


Plan: 1 to add, 0 to change, 0 to destroy.


$ terraform apply
random_string.password: Creating...
  length:  "" => "16"
  lower:   "" => "true"
  number:  "" => "true"
  result:  "" => "<computed>"
  special: "" => "true"
  upper:   "" => "true"
random_string.password: Creation complete (ID: none)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.


$ terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

random_string.password: Refreshing state... (ID: none)
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, Terraform
doesn't need to do anything.


$ terraform apply
random_string.password: Refreshing state... (ID: none)

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```