### PR TITLE
Add import support for random id and random integer

### DIFF
--- a/random/resource_id_test.go
+++ b/random/resource_id_test.go
@@ -37,6 +37,17 @@ func TestAccResourceID(t *testing.T) {
 					}),
 				),
 			},
+			{
+				ResourceName:      "random_id.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:        "random_id.bar",
+				ImportState:         true,
+				ImportStateIdPrefix: "cloud-,",
+				ImportStateVerify:   true,
+			},
 		},
 	})
 }
@@ -85,7 +96,7 @@ resource "random_id" "foo" {
 
 resource "random_id" "bar" {
   byte_length = 4
-	prefix      = "cloud-"
+  prefix      = "cloud-"
 }
 `
 )

--- a/random/resource_integer.go
+++ b/random/resource_integer.go
@@ -3,7 +3,9 @@ package random
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
+	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -12,6 +14,9 @@ func resourceInteger() *schema.Resource {
 		Create: CreateInteger,
 		Read:   RepopulateInteger,
 		Delete: schema.RemoveFromState,
+		Importer: &schema.ResourceImporter{
+			State: ImportInteger,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"keepers": {
@@ -65,4 +70,36 @@ func CreateInteger(d *schema.ResourceData, meta interface{}) error {
 
 func RepopulateInteger(d *schema.ResourceData, _ interface{}) error {
 	return nil
+}
+
+func ImportInteger(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), ",")
+	if len(parts) != 3 && len(parts) != 4 {
+		return nil, fmt.Errorf("Invalid import usage: expecting {result},{min},{max} or {result},{min},{max},{seed}")
+	}
+
+	result, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, errwrap.Wrapf("Error parsing \"result\": {{err}}", err)
+	}
+	d.Set("result", result)
+
+	min, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, errwrap.Wrapf("Error parsing \"min\": {{err}}", err)
+	}
+	d.Set("min", min)
+
+	max, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return nil, errwrap.Wrapf("Error parsing \"max\": {{err}}", err)
+	}
+	d.Set("max", max)
+
+	if len(parts) == 4 {
+		d.Set("seed", parts[3])
+	}
+	d.SetId(parts[0])
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/random/resource_integer_test.go
+++ b/random/resource_integer_test.go
@@ -20,6 +20,12 @@ func TestAccResourceIntegerBasic(t *testing.T) {
 					testAccResourceIntegerBasic("random_integer.integer_1"),
 				),
 			},
+			{
+				ResourceName:      "random_integer.integer_1",
+				ImportState:       true,
+				ImportStateId:     "3,1,3,12345",
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/website/docs/r/id.html.md
+++ b/website/docs/r/id.html.md
@@ -72,3 +72,18 @@ The following attributes are exported:
 * `b64_std` - The generated id presented in base64 without additional transformations.
 * `hex` - The generated id presented in padded hexadecimal digits. This result will always be twice as long as the requested byte length.
 * `dec` - The generated id presented in non-padded decimal digits.
+
+## Import
+
+Random Ids can be imported using the `b64_url` with an optional `prefix`. This can be used to replace a config value with a value
+interpolated from the random provider without experiencing diffs.
+
+Example with no prefix:
+```
+$ terraform import random_id.server p-9hUg
+```
+
+Example with prefix (prefix is separated by a `,`):
+```
+$ terraform import random_id.server my-prefix-,p-9hUg
+```

--- a/website/docs/r/integer.html.md
+++ b/website/docs/r/integer.html.md
@@ -64,3 +64,13 @@ The following attributes are supported:
 
 * `id` - (string) An internal id.
 * `result` - (int) The random Integer result.
+
+## Import
+
+Random integers can be imported using the `result`, `min`, and `max`, with an optional `seed`.
+This can be used to replace a config value with a value interpolated from the random provider without experiencing diffs.
+
+Example (values are separated by a `,`):
+```
+$ terraform import random_integer.priority 15390,1,99999
+```


### PR DESCRIPTION
Allow importing random resources to be able to replace a config value with a value interpolated from the random provider without experiencing diffs.

See https://github.com/terraform-providers/terraform-provider-google/issues/1054 (which then unblocks https://github.com/terraform-providers/terraform-provider-google/issues/780) for more information on why this is a useful feature.

Once this is merged, I'll add import support for the remaining random resources for completeness.