### PR TITLE
Add minimum character constraints to random_string

### DIFF
--- a/random/resource_string.go
+++ b/random/resource_string.go
@@ -2,7 +2,10 @@ package random
 
 import (
 	"crypto/rand"
+	"math/big"
+	"sort"
 
+	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -53,6 +56,34 @@ func resourceString() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"min_numeric": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+				ForceNew: true,
+			},
+
+			"min_upper": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+				ForceNew: true,
+			},
+
+			"min_lower": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+				ForceNew: true,
+			},
+
+			"min_special": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+				ForceNew: true,
+			},
+
 			"override_special": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -75,9 +106,13 @@ func CreateString(d *schema.ResourceData, meta interface{}) error {
 
 	length := d.Get("length").(int)
 	upper := d.Get("upper").(bool)
+	minUpper := d.Get("min_upper").(int)
 	lower := d.Get("lower").(bool)
+	minLower := d.Get("min_lower").(int)
 	number := d.Get("number").(bool)
+	minNumeric := d.Get("min_numeric").(int)
 	special := d.Get("special").(bool)
+	minSpecial := d.Get("min_special").(int)
 	overrideSpecial := d.Get("override_special").(string)
 
 	if overrideSpecial != "" {
@@ -98,17 +133,49 @@ func CreateString(d *schema.ResourceData, meta interface{}) error {
 		chars += specialChars
 	}
 
-	var bytes = make([]byte, length)
-	var l = byte(len(chars))
-
-	rand.Read(bytes)
-
-	for i, b := range bytes {
-		bytes[i] = chars[b%l]
+	minMapping := map[string]int{
+		numChars:     minNumeric,
+		lowerChars:   minLower,
+		upperChars:   minUpper,
+		specialChars: minSpecial,
 	}
-	d.Set("result", string(bytes))
-	d.SetId(string(bytes))
+	var result = make([]byte, 0, length)
+	for k, v := range minMapping {
+		s, err := generateRandomBytes(&k, v)
+		if err != nil {
+			return errwrap.Wrapf("error generating random bytes: {{err}}", err)
+		}
+		result = append(result, s...)
+	}
+	s, err := generateRandomBytes(&chars, length-len(result))
+	if err != nil {
+		return errwrap.Wrapf("error generating random bytes: {{err}}", err)
+	}
+	result = append(result, s...)
+	order := make([]byte, len(result))
+	if _, err := rand.Read(order); err != nil {
+		return errwrap.Wrapf("error generating random bytes: {{err}}", err)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return order[i] < order[j]
+	})
+
+	d.Set("result", string(result))
+	d.SetId(string(result))
 	return nil
+}
+
+func generateRandomBytes(charSet *string, length int) ([]byte, error) {
+	bytes := make([]byte, length)
+	setLen := big.NewInt(int64(len(*charSet)))
+	for i := range bytes {
+		idx, err := rand.Int(rand.Reader, setLen)
+		if err != nil {
+			return nil, err
+		}
+		bytes[i] = (*charSet)[idx.Int64()]
+	}
+	return bytes, nil
 }
 
 func ReadString(d *schema.ResourceData, meta interface{}) error {

--- a/website/docs/r/string.html.md
+++ b/website/docs/r/string.html.md
@@ -9,10 +9,7 @@ description: |-
 # random\_string
 
 The resource `random_string` generates a random permutation of alphanumeric
-characters and optionally special characters.  This resource does not provide
-any guarantee that the random string will contain specific characters.
-ie. if length = 4 and special = true, output could be 'Aa0#' or '1111'
-
+characters and optionally special characters.
 
 ## Example Usage
 
@@ -37,14 +34,26 @@ The following arguments are supported:
 * `upper` - (Optional) (default true) Include uppercase alphabet characters
   in random string.
 
+* `min_upper` - (Optional) (default 0) Minimum number of uppercase alphabet
+  characters in random string.
+
 * `lower` - (Optional) (default true) Include lowercase alphabet characters
   in random string.
+
+* `min_lower` - (Optional) (default 0) Minimum number of lowercase alphabet
+  characters in random string.
 
 * `number` - (Optional) (default true) Include numeric characters in random
   string.
 
+* `min_numeric` - (Optional) (default 0) Minimum number of numeric characters
+  in random string.
+
 * `special` - (Optional) (default true) Include special characters in random
   string. These are '!@#$%&*()-_=+[]{}<>:?'
+
+* `min_special` - (Optional) (default 0) Minimum number of special characters
+  in random string.
 
 * `override_special` - (Optional) Supply your own list of special characters to
   use for string generation.  This overrides characters list in the special


### PR DESCRIPTION
The motivation behind this is to more reliably create passwords that will pass complexity requirements