### PR TITLE
Hotfix: add state migration for the string resource

### DIFF
--- a/random/resource_string.go
+++ b/random/resource_string.go
@@ -15,6 +15,9 @@ func resourceString() *schema.Resource {
 		Read:   ReadString,
 		Delete: schema.RemoveFromState,
 
+		SchemaVersion: 1,
+		MigrateState:  resourceStringMigrateState,
+
 		Schema: map[string]*schema.Schema{
 			"keepers": {
 				Type:     schema.TypeMap,

--- a/random/resource_string_migrate.go
+++ b/random/resource_string_migrate.go
@@ -1,0 +1,46 @@
+package random
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceStringMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found Random String State v0; migrating to v1")
+		return migrateStringStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateStringStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+
+	if v, ok := is.Attributes["min_lower"]; !ok && v == "" {
+		is.Attributes["min_lower"] = "0"
+	}
+
+	if v, ok := is.Attributes["min_numeric"]; !ok && v == "" {
+		is.Attributes["min_numeric"] = "0"
+	}
+
+	if v, ok := is.Attributes["min_upper"]; !ok && v == "" {
+		is.Attributes["min_upper"] = "0"
+	}
+
+	if v, ok := is.Attributes["min_special"]; !ok && v == "" {
+		is.Attributes["min_special"] = "0"
+	}
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+	return is, nil
+}

--- a/random/resource_string_migrate_test.go
+++ b/random/resource_string_migrate_test.go
@@ -1,0 +1,72 @@
+package random
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccResourceStringMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		ID           string
+		Attributes   map[string]string
+		Expected     map[string]string
+		Meta         interface{}
+	}{
+		"v0_without_value": {
+			StateVersion: 0,
+			ID:           "some_id",
+			Attributes:   map[string]string{},
+			Expected: map[string]string{
+				"min_lower":   "0",
+				"min_upper":   "0",
+				"min_numeric": "0",
+				"min_special": "0",
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.ID,
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceStringMigrateState(tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %q, err: %#v", tn, err)
+		}
+
+		for k, v := range tc.Expected {
+			if is.Attributes[k] != v {
+				t.Fatalf(
+					"bad: %s\n\n expected: %#v -> %#v\n got: %#v -> %#v\n in: %#v",
+					tn, k, v, k, is.Attributes[k], is.Attributes)
+			}
+		}
+	}
+}
+
+func TestStringMigrateState_empty(t *testing.T) {
+	var is *terraform.InstanceState
+	var meta interface{}
+
+	// should handle nil
+	is, err := resourceStringMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+	if is != nil {
+		t.Fatalf("expected nil instancestate, got: %#v", is)
+	}
+
+	// should handle non-nil but empty
+	is = &terraform.InstanceState{}
+	is, err = resourceStringMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+}


### PR DESCRIPTION
Set state defaults for the min_* options for users using random <= 1.3.0