### PR TITLE
Check if random_shuffle is given an empty list

### DIFF
--- a/random/resource_shuffle.go
+++ b/random/resource_shuffle.go
@@ -1,6 +1,7 @@
 package random
 
 import (
+	"errors"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -52,6 +53,10 @@ func resourceShuffle() *schema.Resource {
 func CreateShuffle(d *schema.ResourceData, _ interface{}) error {
 	input := d.Get("input").([]interface{})
 	seed := d.Get("seed").(string)
+
+	if len(input) < 1 {
+		return errors.New("input can't be empty")
+	}
 
 	resultCount := d.Get("result_count").(int)
 	if resultCount == 0 {

--- a/random/resource_shuffle.go
+++ b/random/resource_shuffle.go
@@ -1,7 +1,6 @@
 package random
 
 import (
-	"errors"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -54,30 +53,29 @@ func CreateShuffle(d *schema.ResourceData, _ interface{}) error {
 	input := d.Get("input").([]interface{})
 	seed := d.Get("seed").(string)
 
-	if len(input) < 1 {
-		return errors.New("input can't be empty")
-	}
-
 	resultCount := d.Get("result_count").(int)
 	if resultCount == 0 {
 		resultCount = len(input)
 	}
 	result := make([]interface{}, 0, resultCount)
 
-	rand := NewRand(seed)
+	if len(input) > 0 {
+		rand := NewRand(seed)
 
-	// Keep producing permutations until we fill our result
-Batches:
-	for {
-		perm := rand.Perm(len(input))
+		// Keep producing permutations until we fill our result
+	Batches:
+		for {
+			perm := rand.Perm(len(input))
 
-		for _, i := range perm {
-			result = append(result, input[i])
+			for _, i := range perm {
+				result = append(result, input[i])
 
-			if len(result) >= resultCount {
-				break Batches
+				if len(result) >= resultCount {
+					break Batches
+				}
 			}
 		}
+
 	}
 
 	d.SetId("-")

--- a/random/resource_shuffle_test.go
+++ b/random/resource_shuffle_test.go
@@ -14,7 +14,7 @@ func TestAccResourceShuffle(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccResourceShuffleConfig,
 				Check: resource.ComposeTestCheckFunc(
 					// These results are current as of Go 1.6. The Go
@@ -37,6 +37,14 @@ func TestAccResourceShuffle(t *testing.T) {
 					testAccResourceShuffleCheck(
 						"random_shuffle.longer_length",
 						[]string{"a", "c", "b", "e", "d", "a", "e", "d", "c", "b", "a", "b"},
+					),
+					testAccResourceShuffleCheck(
+						"random_shuffle.empty_length",
+						[]string{},
+					),
+					testAccResourceShuffleCheck(
+						"random_shuffle.one_length",
+						[]string{"a"},
 					),
 				),
 			},
@@ -88,4 +96,15 @@ resource "random_shuffle" "longer_length" {
     seed = "-"
     result_count = 12
 }
+resource "random_shuffle" "empty_length" {
+    input = []
+    seed = "-"
+    result_count = 12
+}
+resource "random_shuffle" "one_length" {
+    input = ["a"]
+    seed = "-"
+    result_count = 1
+}
+
 `


### PR DESCRIPTION
Hi,

The following configuration will cause TF to get stuck in the creating step for random_shuffle

```hcl
resource "random_shuffle" "rand-shuffle" {
    input = []
} 
```

Result being:
```
random_shuffle.rand-shuffle: Creating...
  result.#: "" => "<computed>"
random_shuffle.rand-shuffle: Still creating... (10s elapsed)
...
random_shuffle.rand-shuffle: Still creating... (2m50s elapsed)
```

This change validates that at least one element is provided.

Regards Oscar