### PR TITLE
New Resource random_uuid

### DIFF
--- a/random/provider.go
+++ b/random/provider.go
@@ -16,6 +16,7 @@ func Provider() terraform.ResourceProvider {
 			"random_pet":     resourcePet(),
 			"random_string":  resourceString(),
 			"random_integer": resourceInteger(),
+			"random_uuid":    resourceUuid(),
 		},
 	}
 }

--- a/random/resource_uuid.go
+++ b/random/resource_uuid.go
@@ -1,0 +1,62 @@
+package random
+
+import (
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceUuid() *schema.Resource {
+	return &schema.Resource{
+		Create: CreateUuid,
+		Read:   RepopulateUuid,
+		Delete: schema.RemoveFromState,
+		Importer: &schema.ResourceImporter{
+			State: ImportUuid,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"keepers": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"result": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func CreateUuid(d *schema.ResourceData, meta interface{}) error {
+	result, err := uuid.GenerateUUID()
+	if err != nil {
+		return errwrap.Wrapf("error generating uuid: {{err}}", err)
+	}
+	d.Set("result", result)
+	d.SetId(result)
+	return nil
+}
+
+func RepopulateUuid(d *schema.ResourceData, _ interface{}) error {
+	return nil
+}
+
+func ImportUuid(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	id := d.Id()
+	bytes, err := uuid.ParseUUID(id)
+	if err != nil {
+		return nil, errwrap.Wrapf("error parsing uuid bytes: {{err}}", err)
+	}
+	result, err2 := uuid.FormatUUID(bytes)
+	if err2 != nil {
+		return nil, errwrap.Wrapf("error formatting uuid bytes: {{err2}}", err2)
+	}
+
+	d.Set("result", result)
+	d.SetId(result)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/random/resource_uuid_test.go
+++ b/random/resource_uuid_test.go
@@ -1,0 +1,68 @@
+package random
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+type uuidLens struct {
+	result string
+}
+
+func TestAccResourceUUID(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceUUIDConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceUUIDCheck("random_uuid.foo"),
+				),
+			},
+			{
+				ResourceName:      "random_uuid.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "random_uuid.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccResourceUUIDCheck(id string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[id]
+		if !ok {
+			return fmt.Errorf("Not found: %s", id)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		result := rs.Primary.Attributes["result"]
+		matched, err := regexp.MatchString(
+			"[\\da-f]{8}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{12}", result)
+		if !matched || err != nil {
+			return fmt.Errorf("result string format incorrect, is %s", result)
+		}
+
+		return nil
+	}
+}
+
+const (
+	testAccResourceUUIDConfig = `
+resource "random_uuid" "foo" { }
+
+resource "random_uuid" "bar" { }
+`
+)

--- a/website/docs/r/uuid.html.md
+++ b/website/docs/r/uuid.html.md
@@ -1,0 +1,53 @@
+---
+layout: "random"
+page_title: "Random: random_uuid"
+sidebar_current: "docs-random-resource-id"
+description: |-
+  Generates a random identifier.
+---
+
+# random\_id
+
+The resource `random_uuid` generates random uuid string that is intended to be
+used as unique identifiers for other resources.
+
+This resource uses the `hashicorp/go-uuid` to generate a UUID-formatted string
+for use with services needed a unique string identifier.
+
+
+## Example Usage
+
+The following example shows how to generate a unique name for an Azure Resource Group.
+
+```hcl
+resource "random_uuid" "test" { }
+
+resource "azurerm_resource_group" "test" {
+  name     = "${random_uuid.test.result}-rg"
+  location = "Central US"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `keepers` - (Optional) Arbitrary map of values that, when changed, will
+  trigger a new uuid to be generated. See
+  [the main provider documentation](../index.html) for more information.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `result` - The generated uuid presented in string format.
+
+## Import
+
+Random UUID's can be imported. This can be used to replace a config value with a value
+interpolated from the random provider without experiencing diffs.
+
+Example:
+```
+$ terraform import random_uuid.main aabbccdd-eeff-0011-2233-445566778899
+```

--- a/website/docs/r/uuid.html.md
+++ b/website/docs/r/uuid.html.md
@@ -6,7 +6,7 @@ description: |-
   Generates a random identifier.
 ---
 
-# random\_id
+# random\_uuid
 
 The resource `random_uuid` generates random uuid string that is intended to be
 used as unique identifiers for other resources.


### PR DESCRIPTION
New resource to generate a UUID rather than having to create your own concatenation. 
For some of the Azure Resources we need the ability to generate a properly formatted GUID and wanted a cleaner way to generate these ids.