### PR TITLE
WIP: Add import support for resource_string

### DIFF
--- a/random/resource_string.go
+++ b/random/resource_string.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"math/big"
 	"sort"
+	"strconv"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -11,9 +12,12 @@ import (
 
 func resourceString() *schema.Resource {
 	return &schema.Resource{
-		Create:        CreateString,
-		Read:          ReadString,
-		Delete:        schema.RemoveFromState,
+		Create: CreateString,
+		Read:   ReadString,
+		Delete: schema.RemoveFromState,
+		Importer: &schema.ResourceImporter{
+			State: ImportString,
+		},
 		MigrateState:  resourceRandomStringMigrateState,
 		SchemaVersion: 1,
 		Schema: map[string]*schema.Schema{
@@ -162,7 +166,8 @@ func CreateString(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	d.Set("result", string(result))
-	d.SetId("none")
+	d.SetId(string(result))
+
 	return nil
 }
 
@@ -179,6 +184,16 @@ func generateRandomBytes(charSet *string, length int) ([]byte, error) {
 	return bytes, nil
 }
 
-func ReadString(d *schema.ResourceData, meta interface{}) error {
+func ReadString(d *schema.ResourceData, _ interface{}) error {
 	return nil
+}
+
+func ImportString(d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	result := d.Id()
+
+	d.Set("length", strconv.Itoa(len(result)))
+	d.Set("result", result)
+	d.SetId(result)
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/random/resource_string_test.go
+++ b/random/resource_string_test.go
@@ -40,6 +40,16 @@ func TestAccResourceString(t *testing.T) {
 					regexMatch("random_string.min", regexp.MustCompile(`([!#@])`), 1),
 				),
 			},
+			{
+				ResourceName:      "random_string.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "random_string.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -128,6 +138,5 @@ resource "random_string" "min" {
   min_special = 1
   min_numeric = 4
 }
-
 `
 )

--- a/website/docs/r/string.html.md
+++ b/website/docs/r/string.html.md
@@ -73,3 +73,13 @@ The following attributes are exported:
 
 * `result` - Random string generated.
 
+## Import
+
+Random strings can be imported using the `result`.  This can be used to
+replace a config value with a value interpolated from the random provider
+without experiencing diffs.
+
+Example:
+```
+$ terraform import random_string.password foobarbaz
+```


### PR DESCRIPTION
This allows to import passwords in the terraform state instead of having them in the code.

The tests are currently failing and I don't understand why, can you help me out?

```
--- FAIL: TestAccResourceString (0.05s)
        testing.go:434: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

                (map[string]string) {
                }


                (map[string]string) (len=9) {
                 (string) (len=6) "length": (string) (len=2) "12",
                 (string) (len=5) "lower": (string) (len=4) "true",
                 (string) (len=9) "min_lower": (string) (len=1) "0",
                 (string) (len=11) "min_numeric": (string) (len=1) "0",
                 (string) (len=11) "min_special": (string) (len=1) "0",
                 (string) (len=9) "min_upper": (string) (len=1) "0",
                 (string) (len=6) "number": (string) (len=4) "true",
                 (string) (len=7) "special": (string) (len=4) "true",
                 (string) (len=5) "upper": (string) (len=4) "true"
                }

FAIL
exit status 1
FAIL    github.com/terraform-providers/terraform-provider-random/random 0.345s
```