### PR TITLE
Fix #47 random_string leaking sensitive information on rotate

### DIFF
--- a/random/resource_string.go
+++ b/random/resource_string.go
@@ -92,8 +92,9 @@ func resourceString() *schema.Resource {
 			},
 
 			"result": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 		},
 	}


### PR DESCRIPTION
Hi,

This commit resolved the issue reported in #47.

By setting "result" as sensitive the resource behaves as expected:
```
...
number:          "true" => "true"
result:          <sensitive> => <computed> (attribute changed)
special:         "true" => "true"
...
```

Since this provider requires go 1.8 to build however terraform itself requires 1.10+ and therefore I've built this with 1.10. I hope this won't be a problem. If there is anything else I can do please don't hesitate to ask.

Regards Oscar