### PR TITLE
fixing the rds example

### DIFF
--- a/website/docs/r/string.html.md
+++ b/website/docs/r/string.html.md
@@ -19,7 +19,8 @@ This resource *does* use a cryptographic random number generator.
 resource "random_string" "password" {
   length = 16
   special = true
-  override_special = "/@\" "
+  # removing '@' and '$' from the default special character list
+  override_special = '!#%&*()-_=+[]{}<>:?'
 }
 
 resource "aws_db_instance" "example" {


### PR DESCRIPTION
override_special is supposed to be a list of special characters to use in the random string.  Currently the example shows all the characters that RDS doesn't allow:  '/', '@', '"', and ' '.  It should be the other way around, take the default special character list and remove the ones that don't work with rds, '@'.  I also removed '$' from my list as it caused a syntax error and I didn't bother with escaping it.