### PR TITLE
docs: Clarify random_string & random_password usage

### DIFF
--- a/website/docs/r/password.html.md
+++ b/website/docs/r/password.html.md
@@ -3,7 +3,7 @@ layout: "random"
 page_title: "Random: random_password"
 sidebar_current: "docs-random-resource-password"
 description: |-
-  Produces a random string of a length using alphanumeric characters and optionally special characters. The result will be displayed to console or in any logs.
+  Produces a random string of a length using alphanumeric characters and optionally special characters. The result will not be displayed to console.
 ---
 
 # random\_password
@@ -11,7 +11,11 @@ description: |-
 ~> **Note:** Requires random provider version >= 2.2.0
 
 Identical to [random_string](string.html) with the exception that the
-result is treated as sensitive and, thus, not displayed in console output.
+result is treated as sensitive and, thus, _not_ displayed in console output.
+
+~> **Note:** All attributes including the generated password will be stored in
+the raw state as plain-text. [Read more about sensitive data in
+state](/docs/state/sensitive-data.html).
 
 This resource *does* use a cryptographic random number generator.
 
@@ -21,10 +25,14 @@ This resource *does* use a cryptographic random number generator.
 resource "random_password" "password" {
   length = 16
   special = true
-  override_special = "/@\" "
+  override_special = "_%@"
 }
 
 resource "aws_db_instance" "example" {
-  password = "${random_password.password.result}"
+  instance_class = "db.t3.micro"
+  allocated_storage = 64
+  engine = "mysql"
+  username = "someone"
+  password = random_string.password.result
 }
 ```

--- a/website/docs/r/string.html.md
+++ b/website/docs/r/string.html.md
@@ -15,7 +15,7 @@ This resource *does* use a cryptographic random number generator.
 
 Historically this resource's intended usage has been ambiguous as the original example
 used it in a password. For backwards compatibility it will
-continue to exist. For unique ids please use [random_id](id.html), for console and log safe
+continue to exist. For unique ids please use [random_id](id.html), for sensitive
 random values please use [random_password](password.html).
 
 ## Example Usage
@@ -25,12 +25,6 @@ resource "random_string" "random" {
   length = 16
   special = true
   override_special = "/@£$"
-}
-
-resource "aws_instance" "server" {
-  tags = {
-    Deployment = "web-server-${random_string.random.result}"
-  }
 }
 ```
 
@@ -59,7 +53,7 @@ The following arguments are supported:
   in random string.
 
 * `special` - (Optional) (default true) Include special characters in random
-  string. These are '!@#$%&*()-_=+[]{}<>:?'
+  string. These are `!@#$%&*()-_=+[]{}<>:?`
 
 * `min_special` - (Optional) (default 0) Minimum number of special characters
   in random string.
@@ -73,10 +67,8 @@ The following arguments are supported:
   trigger a new id to be generated. See
   [the main provider documentation](../index.html) for more information.
 
-
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `result` - Random string generated.
-


### PR DESCRIPTION
This is to clarify usage of the two resources while acknowledging tradeoffs.

Technically I don't think we can guarantee that the password won't appear in logs. While the resource itself doesn't log the generated password it's common for providers to log requests going to the API, which often includes sensitive data.

Closes #50