### PR TITLE
Fix random providers example documentation

### DIFF
--- a/website/docs/r/password.html.md
+++ b/website/docs/r/password.html.md
@@ -33,6 +33,6 @@ resource "aws_db_instance" "example" {
   allocated_storage = 64
   engine = "mysql"
   username = "someone"
-  password = random_string.password.result
+  password = random_password.password.result
 }
 ```


### PR DESCRIPTION
fix typo in the example usage to provide random_password value.