### PR TITLE
Fix example code in random_password example

### DIFF
--- a/website/docs/r/password.html.md
+++ b/website/docs/r/password.html.md
@@ -33,6 +33,6 @@ resource "aws_db_instance" "example" {
   allocated_storage = 64
   engine = "mysql"
   username = "someone"
-  password = random_string.password.result
+  password = random_password.password.result
 }
 ```


### PR DESCRIPTION
The example code doesn't work because it uses `random_string` instead of `random_password`, giving an error:

    Error: Reference to undeclared resource
    
    A managed resource "random_string" "password" has not been declared in the root module.

https://discuss.hashicorp.com/t/random-password-example-error-what-am-i-doing-wrong/4049