### PR TITLE
Fix code example in random_password resource documentation

### DIFF
--- a/website/docs/r/password.html.md
+++ b/website/docs/r/password.html.md
@@ -33,6 +33,6 @@ resource "aws_db_instance" "example" {
   allocated_storage = 64
   engine = "mysql"
   username = "someone"
-  password = random_string.password.result
+  password = random_password.password.result
 }
 ```


### PR DESCRIPTION
The code example in the `random_password` resource uses `random_string.password.result` while it should use `random_password.password.result`.